### PR TITLE
Keep terminal programs open until a key is pressed

### DIFF
--- a/src/glxinfo
+++ b/src/glxinfo
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-exec $SNAP/graphics/usr/bin/glxinfo
+$SNAP/graphics/usr/bin/glxinfo
+read -p "Press any key to continue."

--- a/src/vulkaninfo
+++ b/src/vulkaninfo
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-exec $SNAP/graphics/usr/bin/vulkaninfo
+$SNAP/graphics/usr/bin/vulkaninfo
+read -p "Press any key to continue."


### PR DESCRIPTION
This adds a `read` command to the end of both `glxinfo` and `vulkaninfo` so it keeps the terminal window open until a key is pressed.